### PR TITLE
Corrección de la navegacion entre capítulos para usuarios no autenticados, usuarios logueados y administradores

### DIFF
--- a/app/Livewire/Courses/CourseProgress.php
+++ b/app/Livewire/Courses/CourseProgress.php
@@ -84,21 +84,6 @@ class CourseProgress extends Component
     
     public function nextChapter()
     {
-        if(Auth::user()->role === 'admin'){
-            if($this->currentChapterIndex < count($this->chapters) - 1){
-                $this->currentChapterIndex++;
-            }
-        }
-
-        if (!Auth::check()) {
-            return;
-        }
-
-        if(!in_array($this->currentChapterIndex, $this->completedChapters))
-        {
-            return;
-        }
-    
         if ($this->currentChapterIndex < count($this->chapters) - 1) {
             $this->currentChapterIndex++;
         }


### PR DESCRIPTION
Corrección de los siguientes errores simplificando el método nextChapter de CourseProgress para que no haya restricciones a la hora de navegar entre capítulos

- Cuando el usuario no está autenticado falla la navegación
- La navegación no deja pasar el capítulo sin marcarlo como completa, el objetivo es que se pueda pasar el capitulo pero no se guarde el progreso